### PR TITLE
Allow Standalone without Rainlab.Blog

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -42,27 +42,31 @@ class Plugin extends PluginBase
     }
 
     public function boot(){
-        PostModel::extend(function($model){
-            $model->belongsToMany['gallery'] = [
-                'PolloZen\SimpleGallery\Models\Gallery',
-                'table'    => 'pollozen_simplegallery_galleries_posts',
-                'key'      => 'post_id',
-                'otherKey' => 'gallery_id'
-            ];
-        });
+        if (PluginManager::instance()->hasPlugin('RainLab.Blog')) {
+            $this->require[] = 'RainLab.Blog';
 
-        PostsController::extendFormFields(function($form, $model){
+            PostModel::extend(function($model){
+                $model->belongsToMany['gallery'] = [
+                    'PolloZen\SimpleGallery\Models\Gallery',
+                    'table'    => 'pollozen_simplegallery_galleries_posts',
+                    'key'      => 'post_id',
+                    'otherKey' => 'gallery_id'
+                ];
+            });
 
-            if(!$model instanceof PostModel) return;
-            if (!$model->exists) return;
+            PostsController::extendFormFields(function($form, $model){
 
-            $form->addSecondaryTabFields([
-                'gallery' => [
-                    'label' => 'pollozen.simplegallery::lang.form.label',
-                    'tab' => 'pollozen.simplegallery::lang.form.tab',
-                    'type' => 'relation'
-                ]
-            ]);
-        });
+                if(!$model instanceof PostModel) return;
+                if (!$model->exists) return;
+
+                $form->addSecondaryTabFields([
+                    'gallery' => [
+                        'label' => 'pollozen.simplegallery::lang.form.label',
+                        'tab' => 'pollozen.simplegallery::lang.form.tab',
+                        'type' => 'relation'
+                    ]
+                ]);
+            });
+        }
     }
 }

--- a/Plugin.php
+++ b/Plugin.php
@@ -10,7 +10,7 @@ use RainLab\Blog\Models\Post as PostModel;
  */
 class Plugin extends PluginBase
 {
-    public $require = ['RainLab.Blog'];
+    public $require = [];
 
     public function registerSettings(){
     }

--- a/models/Gallery.php
+++ b/models/Gallery.php
@@ -1,6 +1,7 @@
 <?php namespace PolloZen\SimpleGallery\Models;
 
 use Model;
+use System\Classes\PluginManager;
 
 /**
  * Gallery Model
@@ -32,12 +33,18 @@ class Gallery extends Model
         'images' => ['System\Models\File', 'order' => 'sort_order'],
     ];
 
-    public $belongsToMany = [
-        'post' => [
-            'RainLab\Blog\Models\Post',
-            'table' => 'pollozen_simplegallery_galleries_posts'
-            ]
-        ];
+    public $belongsToMany = [];
+
+    public function __construct(array $attributes = [])
+    {
+        if (PluginManager::instance()->hasPlugin('RainLab.Blog')) {
+            $this->belongsToMany['post'] = [
+                'RainLab\Blog\Models\Post',
+                'table' => 'pollozen_simplegallery_galleries_posts'
+            ];
+        }
+        parent::__construct($attributes);
+    }
 
     public function setUrl($pageName, $controller)
     {


### PR DESCRIPTION
Since the plugin uses a many to many table for handling the relationship with Rainlab.Blog, it can also be used without it. I have been using an edited version of the plugin in production without any problems.

In case a check for Rainlab.Blog needs to done, this would work:

    if (PluginManager::instance()->hasPlugin('RainLab.Blog')) { }
